### PR TITLE
add __MALLOC_HOOK_VOLATILE for glibc 2.14+ support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ ext/dl/cbtable.func
 ext/dl/dlconfig.h
 ext/dl/dlconfig.rb
 ext/openssl/extconf.h
+ext/tk/config_list
 ext/win32ole/.document
 distro/version.txt
 distro/documentation.html

--- a/patches/tcmalloc_declare_memalign_volatile.patch
+++ b/patches/tcmalloc_declare_memalign_volatile.patch
@@ -1,0 +1,25 @@
+diff --git a/distro/google-perftools-1.7/src/tcmalloc.cc b/distro/google-perftools-1.7/src/tcmalloc.cc
+index 8d94d20..0769425 100644
+--- a/distro/google-perftools-1.7/src/tcmalloc.cc
++++ b/distro/google-perftools-1.7/src/tcmalloc.cc
+@@ -137,6 +137,13 @@
+ # define WIN32_DO_PATCHING 1
+ #endif
+ 
++// GLibc 2.14+ requires the hook functions be declared volatile, based on the value of the
++// define __MALLOC_HOOK_VOLATILE. For compatibility with older/non-GLibc implementations,
++// provide an empty definition.
++#if !defined(__MALLOC_HOOK_VOLATILE)
++#define __MALLOC_HOOK_VOLATILE
++#endif
++
+ using STL_NAMESPACE::max;
+ using STL_NAMESPACE::numeric_limits;
+ using STL_NAMESPACE::vector;
+@@ -1669,5 +1676,5 @@ static void *MemalignOverride(size_t align, size_t size, const void *caller)
+   MallocHook::InvokeNewHook(result, size);
+   return result;
+ }
+-void *(*__memalign_hook)(size_t, size_t, const void *) = MemalignOverride;
++void *(*__MALLOC_HOOK_VOLATILE __memalign_hook)(size_t, size_t, const void *) = MemalignOverride;
+ #endif  // #ifndef TCMALLOC_FOR_DEBUGALLOCATION


### PR DESCRIPTION
This patch touches a file which does not live in the main REE repo which is now unmaintained. It directly alters the underlying behavior of [tcmalloc](http://goog-perftools.sourceforge.net/doc/tcmalloc.html), which is the alternative memory allocator enabled by default in REE. The `source/distro` directory is shipped as part of the tarballs which used to be produced when a new quarterly release of REE was released. For that reason the patch is not committed against the source code it applies to directory since it lives in another repository. So, now that that's out of the way here's an explanation of the patch:

There are a few conditions under which the `__memalign_hook` pointer can be changed without the knowledge of the compiler because of the interaction between the libc allocator implementation and that of tcmalloc. This patch adds backwards-compatible support for compiling REE linked against tcmalloc using glibc versions before 2.14+, when the `volatile` type qualifier became required. If you're familiar with use of `const`, think of `volatile` as the inverse; it tells the compiler to not try to deal with reconciling why the reference changed during compilation.

Without this patch:

``` c
In file included from src/tcmalloc.cc:101:0:
/usr/include/malloc.h:160:39: error: ‘__memalign_hook’ has a previous declaration as ‘void* (* volatile __memalign_hook)(size_t, size_t, const void*)’
 extern void *(*__MALLOC_HOOK_VOLATILE __memalign_hook)(size_t __alignment,
                                       ^
src/tcmalloc.cc: In function ‘void PrintStats(int)’:
src/tcmalloc.cc:523:47: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
   write(STDERR_FILENO, buffer, strlen(buffer));
                                               ^
src/tcmalloc.cc: In function ‘void {anonymous}::ReportLargeAlloc(Length, void*)’:
src/tcmalloc.cc:1010:47: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
   write(STDERR_FILENO, buffer, strlen(buffer));
                                               ^
make: *** [libtcmalloc_minimal_la-tcmalloc.lo] Error 1
```
